### PR TITLE
refactor: remove stdout metric exporter from telemetry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry-stdout",
  "opentelemetry_sdk",
  "thiserror",
  "tokio",
@@ -1334,17 +1333,6 @@ name = "opentelemetry-semantic-conventions"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
-
-[[package]]
-name = "opentelemetry-stdout"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
-dependencies = [
- "chrono",
- "opentelemetry",
- "opentelemetry_sdk",
-]
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -11,7 +11,6 @@ opentelemetry = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.31.0", features = ["tonic", "grpc-tonic"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
-opentelemetry-stdout = "0.31.0"
 tokio = "1.48.0"
 tracing-core = "0.1.34"
 tracing-opentelemetry = "0.32.0"

--- a/crates/telemetry/src/telemetry.rs
+++ b/crates/telemetry/src/telemetry.rs
@@ -50,13 +50,9 @@ fn init_meter_provider() -> Result<SdkMeterProvider, TelemetryError> {
         .with_interval(std::time::Duration::from_secs(30))
         .build();
 
-    let stdout_reader =
-        PeriodicReader::builder(opentelemetry_stdout::MetricExporter::default()).build();
-
     let meter_provider = MeterProviderBuilder::default()
         .with_resource(resource())
         .with_reader(reader)
-        .with_reader(stdout_reader)
         .build();
 
     global::set_meter_provider(meter_provider.clone());


### PR DESCRIPTION
## Summary

- Remove `opentelemetry-stdout` dependency and the stdout `PeriodicReader` from `init_meter_provider()`
- Metrics are now visible via Grafana/Prometheus through the OTEL Collector pipeline (see beep-industries/central#16)

## Test plan

- [ ] `cargo build -p beep-telemetry` compiles cleanly
- [ ] Services using `beep_telemetry::init()` still export metrics to OTEL Collector
- [ ] No more noisy stdout metric dumps in service logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed stdout metrics export from telemetry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->